### PR TITLE
Add theme toggle persistence

### DIFF
--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+
+  const current = localStorage.getItem('theme') || 'light';
+  toggle.checked = current === 'dark';
+  applyTheme(current);
+
+  toggle.addEventListener('change', () => {
+    const theme = toggle.checked ? 'dark' : 'light';
+    localStorage.setItem('theme', theme);
+    applyTheme(theme);
+  });
+});
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+}

--- a/failure.html
+++ b/failure.html
@@ -10,11 +10,16 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <label class="theme-switch">
+      <input type="checkbox" id="theme-toggle" />
+      <span class="slider"></span>
+    </label>
     <div class="container">
       <img src="assets/logo.png" alt="RCM Systems Logo" class="logo" />
       <h2>Oops! Something went wrong.</h2>
       <p>Please try the link again or contact support if the issue persists.</p>
       <a href="https://rcmsystems.net/rcmreports/resetpassword" class="button">Try Again</a>
     </div>
+    <script src="assets/theme.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,11 +7,16 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <label class="theme-switch">
+    <input type="checkbox" id="theme-toggle" />
+    <span class="slider"></span>
+  </label>
   <div class="container">
     <img src="assets/logo.png" alt="RCM Logo" class="logo" />
     <h2>Welcome to RCM Auth Pages</h2>
     <p>This site handles secure password resets and email verifications for <strong>rcmsystems.net</strong>.</p>
     <p>If you arrived here directly, you likely want to go back to the main app.</p>
   </div>
+  <script src="assets/theme.js"></script>
 </body>
 </html>

--- a/resetpassword.html
+++ b/resetpassword.html
@@ -9,12 +9,17 @@
 </head>
 
 <body>
+    <label class="theme-switch">
+      <input type="checkbox" id="theme-toggle" />
+      <span class="slider"></span>
+    </label>
     <div class="container" id="content">
         <!-- initial “loading” state -->
         <img src="assets/logo.png" class="logo" alt="RCM Logo" />
         <h2>Resetting your password…</h2>
     </div>
 
+    <script src="assets/theme.js"></script>
     <script type="module">
         import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.8/+esm';
 

--- a/styles.css
+++ b/styles.css
@@ -1,25 +1,37 @@
 /* Reset and base styles */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root[data-theme="light"] {
+  --bg: #ffffff;
+  --text: #000000;
+  --container-bg: rgba(0, 0, 0, 0.06);
+}
+
+:root[data-theme="dark"] {
+  --bg: linear-gradient(135deg, #1a1a1a, #ff6600);
+  --text: #ffffff;
+  --container-bg: rgba(255, 255, 255, 0.06);
+}
   
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    background: linear-gradient(135deg, #1a1a1a, #ff6600);
-    color: white;
-    min-height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 20px;
-  }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+}
   
   /* Main container */
   .container {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: var(--container-bg);
     backdrop-filter: blur(12px);
     padding: 40px;
     border-radius: 16px;
@@ -101,5 +113,49 @@
     font-size: 14px;
     color: white;
     text-align: center;
+  }
+
+  /* Theme Toggle */
+  .theme-switch {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    display: flex;
+    align-items: center;
+    user-select: none;
+  }
+
+  .theme-switch input {
+    display: none;
+  }
+
+  .theme-switch .slider {
+    width: 40px;
+    height: 20px;
+    background-color: #ccc;
+    border-radius: 10px;
+    position: relative;
+    cursor: pointer;
+    transition: background 0.3s;
+  }
+
+  .theme-switch .slider::before {
+    content: '';
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background-color: white;
+    top: 1px;
+    left: 1px;
+    transition: transform 0.3s;
+  }
+
+  .theme-switch input:checked + .slider {
+    background-color: #4f46e5;
+  }
+
+  .theme-switch input:checked + .slider::before {
+    transform: translateX(20px);
   }
   

--- a/success.html
+++ b/success.html
@@ -10,11 +10,16 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <label class="theme-switch">
+      <input type="checkbox" id="theme-toggle" />
+      <span class="slider"></span>
+    </label>
     <div class="container">
       <img src="assets/logo.png" alt="RCM Systems Logo" class="logo" />
       <h2>You're All Set!</h2>
       <p>Your password has been successfully reset and you're good to go.</p>
       <a href="https://rcmsystems.net/rcmreports" class="button">Return to App</a>
     </div>
+    <script src="assets/theme.js"></script>
   </body>
 </html>

--- a/verifyemail.html
+++ b/verifyemail.html
@@ -7,12 +7,16 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <label class="theme-switch">
+      <input type="checkbox" id="theme-toggle" />
+      <span class="slider"></span>
+    </label>
     <div class="container" id="content">
       <img src="assets/logo.png" alt="RCM Logo" class="logo" />
       <h2 id="title">Verifying your email...</h2>
       <p id="status-message">Please wait while we confirm your account.</p>
     </div>
-
+    <script src="assets/theme.js"></script>
     <script>
       const urlParams = new URLSearchParams(window.location.search);
       const token = urlParams.get('token');


### PR DESCRIPTION
## Summary
- add JS utility to persist theme toggle state
- define CSS variables and theme toggle styles
- insert theme toggle markup and script on each page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840683685ac832a877138c0472ef1b8